### PR TITLE
Allow numeric start of identifier

### DIFF
--- a/src/parts/Identifier.js
+++ b/src/parts/Identifier.js
@@ -1,7 +1,7 @@
 const { Parse } = require('sprache');
 const Identifier = Parse.query(function* () {
     const leading = yield Parse.whiteSpace.many();
-    const name = yield Parse.regex(/[a-z\*][-a-z0-9_\*]*/i)
+    const name = yield Parse.regex(/[a-z0-9\*][-a-z0-9_\*]*/i)
     const trailing = yield Parse.whiteSpace.many();
     return Parse.return(name);
 });


### PR DESCRIPTION
This is contrary to the libconfig spec but the mob_db.conf file uses at least one name which begins with a numeral -- `3rd_Floor_Pass`.

See libconfig spec here:
> All names are case-sensitive. They may consist only of alphanumeric characters, dashes (‘-’), underscores (‘_’), and asterisks (‘*’), and must begin with a letter or asterisk. No other characters are allowed.

https://hyperrealm.github.io/libconfig/libconfig_manual.html